### PR TITLE
feat(icon): quote svg and ammend quote svg styles

### DIFF
--- a/_includes/svg/icon-quote.liquid
+++ b/_includes/svg/icon-quote.liquid
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 40 40"
+     class="svg-icon-quote {{ include.class }}"
+     alt="{{ include.alt | default: 'A quote icon'}}">
+  <path fill="#FF5023" fill-rule="evenodd" d="M38.1424149 35.8266254v-13.250774l-5.0773994-1.9814242L40 7.59133127 33.8080495 4 23.4055728 22.0804954v13.74613h14.7368421Zm-23.4055728 0v-13.250774l-5.07739938-1.9814242L16.5944272 7.59133127 10.4024768 4 0 22.0804954v13.74613h14.7368421Z"/>
+</svg>

--- a/_sass/partials/_page.scss
+++ b/_sass/partials/_page.scss
@@ -260,57 +260,6 @@
     }
   }
 
-  blockquote {
-    position: relative;
-    font-family: $tipo--primary;
-    font-weight: $bold--primary;
-    font-size: 28px;
-    color: $color--base;
-    letter-spacing: -0.8px;
-    line-height: 120%;
-    margin-top: $grid-row--lg;
-    margin-bottom: $grid-row--lg;
-    //Grid
-    grid-column: 7 / span 15;
-    @media (min-width : $bp-tablet) {
-      font-size: 48px;
-      margin-top: $grid-row--xl;
-      margin-bottom: $grid-row--xl;
-    }
-
-    cite {
-      font-family: $tipo--secundary;
-      font-weight: $reg--secundary;
-      font-style: normal;
-      font-size: 14px;
-      color: $color--base;
-      letter-spacing: -0.7px;
-      display: block;
-      margin-top: 1em;
-      @media (min-width : $bp-tablet) {
-        font-size: 16px;
-        margin-top: 2em;
-      }
-    }
-
-    &:before {
-      position: relative;
-      display: inline-block;
-      content: '';
-      width: 40px;
-      height: 40px;
-      background: url("../img/ico/cometes--primary.svg") 0 0/cover no-repeat;
-
-      @media (min-width : $bp-tablet) {
-        position: absolute;
-        width: 80px;
-        height: 80px;
-        top: -36px;
-        left: -96px;
-      }
-    }
-  }
-
   figure {
     margin-top: $grid-row--lg;
     margin-bottom: $grid-row--lg;

--- a/_sass/plugins/tags/_quote.scss
+++ b/_sass/plugins/tags/_quote.scss
@@ -31,13 +31,11 @@ figure.pj-quote {
     }
   }
 
-  &:before {
+  .svg-icon-quote {
     position: relative;
     display: inline-block;
-    content: "";
     width: 40px;
     height: 40px;
-    background: url("../img/ico/cometes--primary.svg") 0 0 / cover no-repeat;
 
     @media (min-width: $bp-tablet) {
       position: absolute;

--- a/jekyll-theme-platoniq-journal.gemspec
+++ b/jekyll-theme-platoniq-journal.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-theme-platoniq-journal"
-  spec.version       = "0.0.11"
+  spec.version       = "0.0.12"
   spec.authors       = ["Agustí B.R."]
   spec.email         = ["agusti@platoniq.net"]
 


### PR DESCRIPTION
## Description

This PR adds a SVG icon, to use with the`quote block tag`

## Related 

- https://github.com/Platoniq/jekyll-plugin-platoniq-journal/pull/3