### PR TITLE
change styles for headers and fix some mobile/tablet styles

### DIFF
--- a/_includes/article/hero.liquid
+++ b/_includes/article/hero.liquid
@@ -11,7 +11,7 @@
         <span class="interviewee">{{ page.interviewee }}</span>
       {% endif %}
 
-      {{ page.title }}
+      <span>{{ page.title }}</span>
     </h1>
 
     <div class="pj-hero__data">

--- a/_includes/default/assigns.liquid
+++ b/_includes/default/assigns.liquid
@@ -38,3 +38,8 @@
 {% assign t_gallery_previous = site.data.i18n[page.locale].article.gallery_previous %}
 {% assign t_gallery_next = site.data.i18n[page.locale].article.gallery_next %}
 
+{% assign volume_archives = site.archives | where: "locale", page.locale | where: "volume-uid", current_volume.uid | sort: "order" %}
+{% assign global_archives = site.archives | where: "locale", page.locale | where: "volume-uid", nil %}
+
+{% assign archives = volume_archives | join: global_archives %}
+

--- a/_includes/default/header_sitemap_selector.liquid
+++ b/_includes/default/header_sitemap_selector.liquid
@@ -63,10 +63,9 @@
     {% endif %}
 
     <hr>
+    {% assign volume_archives = site.archives | where: "locale", page.locale | where: "volume-uid", current_volume.uid | sort: "order" %}
 
-    {% assign archives = site.archives | where: "locale", page.locale | where: "volume-uid", current_volume.uid %}
-    
-    {% for archive in archives %}
+    {% for archive in volume_archives %}
       {% assign category_articles = site.articles | where: "published", true | where: "category", archive.category | where: "locale", page.locale | where: "volume-uid", current_volume.uid %}
       {% assign t_category_name = site.data.i18n[page.locale].categories[archive.category] %}
   
@@ -97,9 +96,6 @@
       {% endunless %}
     {% endfor %}
 
-    {% assign global_archives = site.archives | where: "locale", page.locale | where: "volume-uid", nil %}
-
-    <h2>{{ global_archives.title }}</h2>
     {% for global_archive in global_archives %}
       {% assign category_articles = site.articles | where: "published", true | where: "category", global_archive.category | where: "locale", page.locale | where: "volume-uid", nil %}
       {% assign t_category_name = site.data.i18n[page.locale].categories[global_archive.category] %}

--- a/_includes/journal/nav_categories.liquid
+++ b/_includes/journal/nav_categories.liquid
@@ -1,8 +1,7 @@
 <nav class="pj-nav-vertical">
   <ul>
-  {% assign archives = site.archives | where: "locale", page.locale | where: "volume-uid", current_volume.uid %}
-
-  {% for archive in archives %}
+  {% assign volume_archives = site.archives | where: "locale", page.locale | where: "volume-uid", current_volume.uid | sort: "order" %}
+  {% for archive in volume_archives %}
     {% assign t_category_name = site.data.i18n[page.locale].categories[archive.category] %}
 
     <li>

--- a/_includes/journal/section_main.liquid
+++ b/_includes/journal/section_main.liquid
@@ -35,8 +35,6 @@
               {{ article.title }}
             </a>
           </h3>
-
-          <h5>{{ article.author | prepend: t_authored_by }}</h5>
         </article>
       {% if mod != 0 %}
         </div> <!-- mod != 0  -->

--- a/_sass/partials/_home.scss
+++ b/_sass/partials/_home.scss
@@ -1,14 +1,8 @@
 .grid {
-  display: flex;
-  flex-flow: column;
-
-  @media (min-width: $bp-tablet) {
-    display: grid;
-    grid-template-columns: repeat(24, 1fr);
-    grid-gap: 16px;
-    grid-column-gap: 16px;
-    grid-row-gap: $grid-row-xxl;
-  }
+  display: grid;
+  grid-gap: 16px;
+  grid-column-gap: 16px;
+  grid-row-gap: $grid-row-xxl;
 }
 
 .pj-articles {

--- a/_sass/partials/_page.scss
+++ b/_sass/partials/_page.scss
@@ -8,6 +8,7 @@
   }
 
   .grid {
+    grid-template-columns: repeat(24, 1fr);
     grid-row-gap: $grid-row-lg;
 
     @media (max-width: $bp-tablet) {

--- a/_sass/partials/home/_home_hero.scss
+++ b/_sass/partials/home/_home_hero.scss
@@ -9,12 +9,17 @@
   background-size: cover;
 
   &.grid {
-    align-content: center;
-    justify-content: center;
+    grid-template-rows: repeat(24, 1fr);
+    grid-template-columns: repeat(12, 1fr);
   }
 
   &__text {
-    grid-column: 3 / span 12;
+    grid-column: 2 / span 6;
+    grid-row: 2;
+
+    @media(max-width: $bp-desktop) {
+      grid-column: 2 / span 16;
+    }
   }
 
   h1 {
@@ -24,14 +29,14 @@
     letter-spacing: -1px;
 
 
-    @media (max-width: $bp-mobile) {
-      font-size: calc(56px * 0.75); 
+    @media (min-width: $bp-mobile) {
+      font-size: 2rem;
     }
     @media (min-width: $bp-tablet) {
-      font-size: calc(120px * 0.75);
+      font-size: 4rem;
     }
-    @media (min-width: $bp-desktop-xxl) {
-      font-size: 120px;
+    @media (min-width: $bp-desktop-xl) {
+      font-size: 6rem;
     }
   }
 
@@ -134,7 +139,7 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: $bp-desktop) {
   .heroimage {
     background-image: var(--heroimage-mobile-cover-image);
   }

--- a/_sass/partials/home/_home_hero.scss
+++ b/_sass/partials/home/_home_hero.scss
@@ -23,7 +23,7 @@
   }
 
   h1 {
-    @include font-heading(56px);
+    @include font-heading(2rem);
 
     color: $color-white;
     letter-spacing: -1px;

--- a/_sass/partials/home/_home_main.scss
+++ b/_sass/partials/home/_home_main.scss
@@ -8,9 +8,22 @@
     grid-row-gap: $grid-row-lg;
   }
 
+  .grid {
+    @media (min-width: $bp-mobile) {
+      grid-template-columns: 1fr 1fr;
+    }
+
+    @media (min-width: $bp-tablet) {
+      grid-template-columns: repeat(24, 1fr);
+    }
+  }
+
+
+
   .row-articles {
     width: 100%;
     padding-left: 60px;
+    grid-column: 1 / 3;
 
     @media (min-width: $bp-tablet) {
       padding-left: 0;
@@ -74,7 +87,7 @@
       letter-spacing: -0.4px;
       line-height: 115%;
 
-      @media (min-width: $bp-tablet) {
+      @media (min-width: $bp-desktop) {
         font-size: 40px;
         padding-top: 8px;
       }
@@ -145,7 +158,6 @@
     &-horizontal {
       img {
         margin: 0 auto;
-        padding-left: 40px;
         max-width: calc(100% - 32px);
         align-self: center;
       }
@@ -154,7 +166,6 @@
     &-vertical {
       img {
         margin: 0 auto;
-        padding-left: 40px;
         max-width: calc(100% - 32px);
         align-self: center;
       }

--- a/_sass/partials/page/_header.scss
+++ b/_sass/partials/page/_header.scss
@@ -128,6 +128,12 @@
       padding: 0.188em 0.375em;
       margin-bottom: 0.25em;
     }
+
+
+    span {
+      background-color: $color-bg-secondary;
+      color: $color-fg-secondary;
+    }
   }
 
   h4 {


### PR DESCRIPTION
#### :tophat: What? Why?
*Please describe your pull request.*

Change some styles for the landing of the second volume of the journal.

The layout of the header of the landign has been changed to work as grid for every width. Also, the articles inside the home layout have been changed to work also with grid and the amount of space they use in a tablet have been improved.

#### Testing
*Describe the best way to test or validate your PR.*
You can test this new development with the [wilder journal](https://github.com/platoniq/wilder-journal-next) to see the actual content this PR improves.

### :camera: Screenshots

#### Header
![new header](https://github.com/Platoniq/jekyll-theme-platoniq-journal/assets/41389482/eab5a044-c3da-4f20-8745-3b69b0200c0e)

![old](https://github.com/Platoniq/jekyll-theme-platoniq-journal/assets/41389482/0493e599-328e-4354-a0c4-a709dd6e0091)

#### Tablet layout

Old layout
![image](https://github.com/Platoniq/jekyll-theme-platoniq-journal/assets/41389482/310a9228-278b-415e-b51b-ed49d10a631d)

![image](https://github.com/Platoniq/jekyll-theme-platoniq-journal/assets/41389482/405821a2-e900-4521-8df9-7fcba1f18e00)

New layout

![image](https://github.com/Platoniq/jekyll-theme-platoniq-journal/assets/41389482/adaa2fae-f91f-4821-86d9-72f6543ccfd9)

![image](https://github.com/Platoniq/jekyll-theme-platoniq-journal/assets/41389482/acef6d2c-f9b3-44ee-85c7-03c3b74fbaf0)

:hearts: Thank you!
